### PR TITLE
feat: add MXP protocol support (v2.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.5.0]
+
+### Added
+- **MXP Protocol** — `MXPProtocol` plugin implementing MUD eXtension Protocol (telnet option 91) handshake negotiation. Server sends `IAC WILL MXP`, client responds `IAC DO MXP`. Included in `AddDefaultMUDProtocols()`.
+- `.OnMXPEnabled(() => ...)` fluent callback for MXP negotiation success
+- `MXPProtocol.IsMXPActive` property to check negotiation state
+
 ## [2.4.2]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ This library is in a stable state. The legacy API remains fully supported for ba
 | [RFC 1408](http://www.faqs.org/rfcs/rfc1408.html)   | Environment Negotiation            | Full       |                    | 
 | [RFC 2941](http://www.faqs.org/rfcs/rfc2941.html)   | Authentication Negotiation         | Full       |                    |
 | [RFC 2946](http://www.faqs.org/rfcs/rfc2946.html)   | Encryption Negotiation             | Full       |                    |
+| [MXP](https://www.zuggsoft.com/zmud/mxp.htm)       | MUD eXtension Protocol             | Full       | Telnet option 91   |
 
 ## ANSI Support, ETC?
-Being a Telnet Negotiation Library, this library doesn't give support for extensions like ANSI, Pueblo, MXP, etc at this time.
+Being a Telnet Negotiation Library, this library doesn't give support for extensions like ANSI or Pueblo at this time. MXP negotiation (telnet option 91) is supported — see the MXP protocol plugin.
 
 ## Use
 
@@ -65,12 +66,13 @@ var (telnet, readTask) = await new TelnetInterpreterBuilder()
         .WithCharsetOrder(Encoding.UTF8, Encoding.GetEncoding("iso-8859-1"))
     .AddPlugin<EORProtocol>()
     .AddPlugin<SuppressGoAheadProtocol>()
+    .AddPlugin<MXPProtocol>()
     .BuildAndStartAsync(connection.Transport);   // IDuplexPipe (Kestrel), TcpClient, or Stream
 
 await readTask; // completes when the connection closes
 ```
 
-`AddDefaultMUDProtocols()` registers NAWS, GMCP, MSDP, MSSP, Terminal Type, Charset, EOR, and Suppress Go-Ahead in one call:
+`AddDefaultMUDProtocols()` registers NAWS, GMCP, MSDP, MSSP, Terminal Type, Charset, EOR, Suppress Go-Ahead, and MXP in one call:
 
 ```csharp
 var (telnet, readTask) = await new TelnetInterpreterBuilder()
@@ -104,7 +106,8 @@ builder.Services.AddTelnetServer(telnet => telnet
     .AddPlugin<CharsetProtocol>()
         .WithCharsetOrder(Encoding.UTF8, Encoding.GetEncoding("iso-8859-1"))
     .AddPlugin<EORProtocol>()
-    .AddPlugin<SuppressGoAheadProtocol>());
+    .AddPlugin<SuppressGoAheadProtocol>()
+    .AddPlugin<MXPProtocol>());
 
 builder.WebHost.UseKestrel(options =>
     options.ListenLocalhost(4202, listenOptions =>
@@ -155,6 +158,7 @@ All plugin callbacks and settings are set inline on the builder:
 - `.WithMSSPConfig(() => new MSSPConfig { ... })` — server advertisement data
 - `.WithCharsetOrder(Encoding.UTF8, ...)` — encoding preference order
 - `.WithTTableSupport(true)` / `.OnTTableReceived(...)` / `.OnTTableRequested(...)` — TTABLE support (RFC 2066)
+- `.OnMXPEnabled(() => ...)` — MXP negotiation success
 
 ### Manual Connection Management
 
@@ -1111,6 +1115,7 @@ public override async Task OnConnectedAsync(ConnectionContext connection)
             .WithCharsetOrder(Encoding.UTF8, Encoding.GetEncoding("iso-8859-1"))
         .AddPlugin<EORProtocol>()
         .AddPlugin<SuppressGoAheadProtocol>()
+        .AddPlugin<MXPProtocol>()
         .BuildAndStartAsync(connection.Transport);
 
     await readTask;

--- a/TelnetNegotiationCore.UnitTests/MXPTests.cs
+++ b/TelnetNegotiationCore.UnitTests/MXPTests.cs
@@ -1,0 +1,214 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using TelnetNegotiationCore.Builders;
+using TelnetNegotiationCore.Interpreters;
+using TelnetNegotiationCore.Models;
+using TelnetNegotiationCore.Protocols;
+using TUnit.Core;
+
+namespace TelnetNegotiationCore.UnitTests;
+
+public class MXPTests : BaseTest
+{
+	private static async Task<bool> PollUntilAsync(Func<bool> condition, int timeoutMs = 2000, int pollIntervalMs = 10)
+	{
+		var waitedMs = 0;
+		while (!condition() && waitedMs < timeoutMs)
+		{
+			await Task.Delay(pollIntervalMs);
+			waitedMs += pollIntervalMs;
+		}
+		return condition();
+	}
+
+	[Test]
+	public async Task ServerAnnouncesMXPOnBuild()
+	{
+		// Arrange
+		byte[] negotiationOutput = null;
+
+		ValueTask WriteBackToNegotiate(ReadOnlyMemory<byte> arg1)
+		{
+			negotiationOutput = arg1.ToArray();
+			return ValueTask.CompletedTask;
+		}
+
+		var server_ti = await new TelnetInterpreterBuilder()
+			.UseMode(TelnetInterpreter.TelnetMode.Server)
+			.UseLogger(logger)
+			.OnSubmit(NoOpSubmitCallback)
+			.OnNegotiation(WriteBackToNegotiate)
+			.AddPlugin<MXPProtocol>()
+			.BuildAsync();
+
+		// Assert - Server should announce WILL MXP during initialization
+		await Assert.That(negotiationOutput).IsNotNull();
+		await AssertByteArraysEqual(negotiationOutput, new byte[] { (byte)Trigger.IAC, (byte)Trigger.WILL, (byte)Trigger.MXP });
+
+		await server_ti.DisposeAsync();
+	}
+
+	[Test]
+	public async Task ClientRespondsDoMXPToServerWill()
+	{
+		// Arrange
+		byte[] negotiationOutput = null;
+
+		ValueTask WriteBackToNegotiate(ReadOnlyMemory<byte> arg1)
+		{
+			negotiationOutput = arg1.ToArray();
+			return ValueTask.CompletedTask;
+		}
+
+		var client_ti = await new TelnetInterpreterBuilder()
+			.UseMode(TelnetInterpreter.TelnetMode.Client)
+			.UseLogger(logger)
+			.OnSubmit(NoOpSubmitCallback)
+			.OnNegotiation(WriteBackToNegotiate)
+			.AddPlugin<MXPProtocol>()
+			.BuildAsync();
+
+		// Act - Server sends WILL MXP
+		await client_ti.InterpretByteArrayAsync(new byte[] { (byte)Trigger.IAC, (byte)Trigger.WILL, (byte)Trigger.MXP });
+		await client_ti.WaitForProcessingAsync();
+
+		// Assert - Client should respond with DO MXP
+		await Assert.That(negotiationOutput).IsNotNull();
+		await AssertByteArraysEqual(negotiationOutput, new byte[] { (byte)Trigger.IAC, (byte)Trigger.DO, (byte)Trigger.MXP });
+
+		await client_ti.DisposeAsync();
+	}
+
+	[Test]
+	public async Task ServerMXPEnabledOnClientDo()
+	{
+		// Arrange
+		byte[] negotiationOutput = null;
+		bool mxpEnabledCallbackFired = false;
+
+		ValueTask WriteBackToNegotiate(ReadOnlyMemory<byte> arg1)
+		{
+			negotiationOutput = arg1.ToArray();
+			return ValueTask.CompletedTask;
+		}
+
+		var server_ti = await new TelnetInterpreterBuilder()
+			.UseMode(TelnetInterpreter.TelnetMode.Server)
+			.UseLogger(logger)
+			.OnSubmit(NoOpSubmitCallback)
+			.OnNegotiation(WriteBackToNegotiate)
+			.AddPlugin<MXPProtocol>()
+				.OnMXPEnabled(() =>
+				{
+					mxpEnabledCallbackFired = true;
+					return ValueTask.CompletedTask;
+				})
+			.BuildAsync();
+
+		var mxpPlugin = server_ti.PluginManager!.GetPlugin<MXPProtocol>();
+
+		// Act - Client sends DO MXP
+		await server_ti.InterpretByteArrayAsync(new byte[] { (byte)Trigger.IAC, (byte)Trigger.DO, (byte)Trigger.MXP });
+		await server_ti.WaitForProcessingAsync();
+
+		var gotCallback = await PollUntilAsync(() => mxpEnabledCallbackFired);
+
+		// Assert
+		await Assert.That(gotCallback).IsTrue();
+		await Assert.That(mxpPlugin!.IsMXPActive).IsTrue();
+
+		await server_ti.DisposeAsync();
+	}
+
+	[Test]
+	public async Task ClientMXPEnabledOnServerWill()
+	{
+		// Arrange
+		bool mxpEnabledCallbackFired = false;
+
+		ValueTask WriteBackToNegotiate(ReadOnlyMemory<byte> arg1) => ValueTask.CompletedTask;
+
+		var client_ti = await new TelnetInterpreterBuilder()
+			.UseMode(TelnetInterpreter.TelnetMode.Client)
+			.UseLogger(logger)
+			.OnSubmit(NoOpSubmitCallback)
+			.OnNegotiation(WriteBackToNegotiate)
+			.AddPlugin<MXPProtocol>()
+				.OnMXPEnabled(() =>
+				{
+					mxpEnabledCallbackFired = true;
+					return ValueTask.CompletedTask;
+				})
+			.BuildAsync();
+
+		var mxpPlugin = client_ti.PluginManager!.GetPlugin<MXPProtocol>();
+
+		// Act - Server sends WILL MXP
+		await client_ti.InterpretByteArrayAsync(new byte[] { (byte)Trigger.IAC, (byte)Trigger.WILL, (byte)Trigger.MXP });
+		await client_ti.WaitForProcessingAsync();
+
+		var gotCallback = await PollUntilAsync(() => mxpEnabledCallbackFired);
+
+		// Assert
+		await Assert.That(gotCallback).IsTrue();
+		await Assert.That(mxpPlugin!.IsMXPActive).IsTrue();
+
+		await client_ti.DisposeAsync();
+	}
+
+	[Test]
+	public async Task ServerMXPDisabledOnClientDont()
+	{
+		// Arrange
+		ValueTask WriteBackToNegotiate(ReadOnlyMemory<byte> arg1) => ValueTask.CompletedTask;
+
+		var server_ti = await new TelnetInterpreterBuilder()
+			.UseMode(TelnetInterpreter.TelnetMode.Server)
+			.UseLogger(logger)
+			.OnSubmit(NoOpSubmitCallback)
+			.OnNegotiation(WriteBackToNegotiate)
+			.AddPlugin<MXPProtocol>()
+			.BuildAsync();
+
+		var mxpPlugin = server_ti.PluginManager!.GetPlugin<MXPProtocol>();
+
+		// Act - Client sends DONT MXP
+		await server_ti.InterpretByteArrayAsync(new byte[] { (byte)Trigger.IAC, (byte)Trigger.DONT, (byte)Trigger.MXP });
+		await server_ti.WaitForProcessingAsync();
+		await Task.Delay(100);
+
+		// Assert
+		await Assert.That(mxpPlugin!.IsMXPActive).IsFalse();
+
+		await server_ti.DisposeAsync();
+	}
+
+	[Test]
+	public async Task ClientMXPDisabledOnServerWont()
+	{
+		// Arrange
+		ValueTask WriteBackToNegotiate(ReadOnlyMemory<byte> arg1) => ValueTask.CompletedTask;
+
+		var client_ti = await new TelnetInterpreterBuilder()
+			.UseMode(TelnetInterpreter.TelnetMode.Client)
+			.UseLogger(logger)
+			.OnSubmit(NoOpSubmitCallback)
+			.OnNegotiation(WriteBackToNegotiate)
+			.AddPlugin<MXPProtocol>()
+			.BuildAsync();
+
+		var mxpPlugin = client_ti.PluginManager!.GetPlugin<MXPProtocol>();
+
+		// Act - Server sends WONT MXP
+		await client_ti.InterpretByteArrayAsync(new byte[] { (byte)Trigger.IAC, (byte)Trigger.WONT, (byte)Trigger.MXP });
+		await client_ti.WaitForProcessingAsync();
+		await Task.Delay(100);
+
+		// Assert
+		await Assert.That(mxpPlugin!.IsMXPActive).IsFalse();
+
+		await client_ti.DisposeAsync();
+	}
+}

--- a/TelnetNegotiationCore/Builders/PluginConfigurationExtensions.cs
+++ b/TelnetNegotiationCore/Builders/PluginConfigurationExtensions.cs
@@ -407,4 +407,18 @@ public static class PluginConfigurationExtensions
         context.Plugin.WithClientDisplayLocation(displayLocation);
         return context;
     }
+
+    /// <summary>
+    /// Sets the MXP enabled callback in a fluent manner.
+    /// </summary>
+    /// <param name="context">The plugin configuration context</param>
+    /// <param name="callback">The callback to handle MXP activation</param>
+    /// <returns>The configuration context for continued chaining</returns>
+    public static PluginConfigurationContext<MXPProtocol> OnMXPEnabled(
+        this PluginConfigurationContext<MXPProtocol> context,
+        Func<ValueTask>? callback)
+    {
+        context.Plugin.OnMXPEnabled(callback);
+        return context;
+    }
 }

--- a/TelnetNegotiationCore/Builders/TelnetInterpreterBuilderExtensions.cs
+++ b/TelnetNegotiationCore/Builders/TelnetInterpreterBuilderExtensions.cs
@@ -36,7 +36,8 @@ public static class TelnetInterpreterBuilderExtensions
         Func<Interpreters.TelnetInterpreter, string, ValueTask>? onMSDPMessage = null,
         Func<ValueTask>? onPrompt = null,
         Encoding[]? charsetOrder = null,
-        Func<int, bool, ValueTask>? onCompressionEnabled = null)
+        Func<int, bool, ValueTask>? onCompressionEnabled = null,
+        Func<ValueTask>? onMXPEnabled = null)
     {
         if (builder == null)
             throw new ArgumentNullException(nameof(builder));
@@ -81,15 +82,20 @@ public static class TelnetInterpreterBuilderExtensions
         if (onPrompt != null)
             sgaContext = sgaContext.OnPrompt(onPrompt);
 
+        // Add MXP protocol
+        var mxpContext = sgaContext.AddPlugin<MXPProtocol>();
+        if (onMXPEnabled != null)
+            mxpContext = mxpContext.OnMXPEnabled(onMXPEnabled);
+
         // Add MCCP protocol if compression callback is provided
         if (onCompressionEnabled != null)
         {
-            var mccpContext = sgaContext.AddPlugin<MCCPProtocol>();
+            var mccpContext = mxpContext.AddPlugin<MCCPProtocol>();
             mccpContext = mccpContext.OnCompressionEnabled(onCompressionEnabled);
             return mccpContext;
         }
 
-        return sgaContext;
+        return mxpContext;
     }
 
     /// <summary>

--- a/TelnetNegotiationCore/Models/State.cs
+++ b/TelnetNegotiationCore/Models/State.cs
@@ -99,6 +99,12 @@ public enum State : short
 	EscapingGMCPValue,
 	CompletingGMCPValue,
 	#endregion GMCP Negotiation
+	#region MXP Negotiation
+	DoMXP,
+	DontMXP,
+	WillMXP,
+	WontMXP,
+	#endregion MXP Negotiation
 	#region MSDP Negotiation
 	DontMSDP,
 	DoMSDP,

--- a/TelnetNegotiationCore/Models/Trigger.cs
+++ b/TelnetNegotiationCore/Models/Trigger.cs
@@ -308,6 +308,13 @@ public enum Trigger : short
 	/// </remarks>
 	MCCP2 = 86,
 	MCCP3 = 87,
+	/// <summary>
+	/// MUD eXtension Protocol
+	/// </summary>
+	/// <remarks>
+	/// MXP: https://www.zuggsoft.com/zmud/mxp.htm
+	/// </remarks>
+	MXP = 91,
 	/// Generic Mud Communication Protocol	
 	/// </summary>
 	/// <remarks>

--- a/TelnetNegotiationCore/Protocols/MXPProtocol.cs
+++ b/TelnetNegotiationCore/Protocols/MXPProtocol.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Stateless;
+using TelnetNegotiationCore.Attributes;
+using TelnetNegotiationCore.Models;
+using TelnetNegotiationCore.Plugins;
+
+namespace TelnetNegotiationCore.Protocols;
+
+/// <summary>
+/// MXP (MUD eXtension Protocol) plugin implementation.
+/// MXP uses telnet option 91 (0x5B) and enables rich content tags in MUD output.
+/// </summary>
+/// <remarks>
+/// This protocol optionally accepts configuration. Call <see cref="OnMXPEnabled"/> to set up
+/// the callback that will be invoked when the remote endpoint agrees to MXP.
+/// </remarks>
+[RequiredMethod("OnMXPEnabled", Description = "Configure the callback to handle MXP activation (optional but recommended)")]
+public class MXPProtocol : TelnetProtocolPluginBase
+{
+    private static readonly byte[] s_willMxp = [(byte)Trigger.IAC, (byte)Trigger.WILL, (byte)Trigger.MXP];
+    private static readonly byte[] s_doMxp = [(byte)Trigger.IAC, (byte)Trigger.DO, (byte)Trigger.MXP];
+    private static readonly byte[] s_dontMxp = [(byte)Trigger.IAC, (byte)Trigger.DONT, (byte)Trigger.MXP];
+    private static readonly byte[] s_wontMxp = [(byte)Trigger.IAC, (byte)Trigger.WONT, (byte)Trigger.MXP];
+
+    private bool? _mxpEnabled = null;
+    private Func<ValueTask>? _onMXPEnabled;
+
+    /// <summary>
+    /// Sets the callback that is invoked when MXP is successfully negotiated.
+    /// </summary>
+    /// <param name="callback">The callback to handle MXP activation</param>
+    /// <returns>This instance for fluent chaining</returns>
+    public MXPProtocol OnMXPEnabled(Func<ValueTask>? callback)
+    {
+        _onMXPEnabled = callback;
+        return this;
+    }
+
+    /// <summary>
+    /// Indicates whether MXP has been negotiated and is active.
+    /// </summary>
+    public bool IsMXPActive => _mxpEnabled == true;
+
+    /// <inheritdoc />
+    public override Type ProtocolType => typeof(MXPProtocol);
+
+    /// <inheritdoc />
+    public override string ProtocolName => "MXP (MUD eXtension Protocol)";
+
+    /// <inheritdoc />
+    public override IReadOnlyCollection<Type> Dependencies => Array.Empty<Type>();
+
+    /// <inheritdoc />
+    public override void ConfigureStateMachine(StateMachine<State, Trigger> stateMachine, IProtocolContext context)
+    {
+        context.Logger.LogInformation("Configuring MXP state machine");
+
+        context.SetSharedState("MXP_Protocol", this);
+
+        if (context.Mode == Interpreters.TelnetInterpreter.TelnetMode.Server)
+        {
+            stateMachine.Configure(State.Do)
+                .Permit(Trigger.MXP, State.DoMXP);
+
+            stateMachine.Configure(State.Dont)
+                .Permit(Trigger.MXP, State.DontMXP);
+
+            stateMachine.Configure(State.DoMXP)
+                .SubstateOf(State.Accepting)
+                .OnEntryAsync(async _ => await OnDoMXPAsync(context));
+
+            stateMachine.Configure(State.DontMXP)
+                .SubstateOf(State.Accepting)
+                .OnEntryAsync(async () => await OnDontMXPAsync(context));
+
+            context.RegisterInitialNegotiation(async () => await WillingMXPAsync(context));
+        }
+        else
+        {
+            stateMachine.Configure(State.Willing)
+                .Permit(Trigger.MXP, State.WillMXP);
+
+            stateMachine.Configure(State.Refusing)
+                .Permit(Trigger.MXP, State.WontMXP);
+
+            stateMachine.Configure(State.WontMXP)
+                .SubstateOf(State.Accepting)
+                .OnEntryAsync(async () => await WontMXPAsync(context));
+
+            stateMachine.Configure(State.WillMXP)
+                .SubstateOf(State.Accepting)
+                .OnEntryAsync(async _ => await OnWillMXPAsync(context));
+        }
+    }
+
+    /// <inheritdoc />
+    protected override ValueTask OnInitializeAsync()
+    {
+        Context.Logger.LogInformation("MXP Protocol initialized");
+        return default;
+    }
+
+    /// <inheritdoc />
+    protected override ValueTask OnProtocolEnabledAsync()
+    {
+        Context.Logger.LogInformation("MXP Protocol enabled");
+        _mxpEnabled = true;
+        return default;
+    }
+
+    /// <inheritdoc />
+    protected override ValueTask OnProtocolDisabledAsync()
+    {
+        Context.Logger.LogInformation("MXP Protocol disabled");
+        _mxpEnabled = false;
+        return default;
+    }
+
+    /// <inheritdoc />
+    protected override ValueTask OnDisposeAsync()
+    {
+        _mxpEnabled = null;
+        return default;
+    }
+
+    #region State Machine Handlers
+
+    private async ValueTask WillingMXPAsync(IProtocolContext context)
+    {
+        context.Logger.LogDebug("Announcing willingness to MXP!");
+        await context.SendNegotiationAsync(s_willMxp);
+    }
+
+    private async ValueTask OnDoMXPAsync(IProtocolContext context)
+    {
+        context.Logger.LogDebug("Client supports MXP.");
+        _mxpEnabled = true;
+
+        if (_onMXPEnabled != null)
+            await _onMXPEnabled().ConfigureAwait(false);
+    }
+
+    private ValueTask OnDontMXPAsync(IProtocolContext context)
+    {
+        context.Logger.LogDebug("Client won't do MXP - do nothing");
+        _mxpEnabled = false;
+        return default;
+    }
+
+    private ValueTask WontMXPAsync(IProtocolContext context)
+    {
+        context.Logger.LogDebug("Server won't do MXP - do nothing");
+        _mxpEnabled = false;
+        return default;
+    }
+
+    private async ValueTask OnWillMXPAsync(IProtocolContext context)
+    {
+        context.Logger.LogDebug("Server supports MXP.");
+        _mxpEnabled = true;
+        await context.SendNegotiationAsync(s_doMxp);
+
+        if (_onMXPEnabled != null)
+            await _onMXPEnabled().ConfigureAwait(false);
+    }
+
+    #endregion
+}

--- a/TelnetNegotiationCore/TelnetNegotiationCore.csproj
+++ b/TelnetNegotiationCore/TelnetNegotiationCore.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
-		<Version>2.3.0</Version>
+		<Version>2.5.0</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>Telnet Negotiation Core</Title>
 		<PackageId>$(AssemblyName)</PackageId>


### PR DESCRIPTION
Adds MXP (MUD eXtension Protocol) support via the plugin architecture.

## Changes
- New `MXPProtocol.cs` protocol handler
- Updated plugin configuration extensions
- Updated builder extensions
- Added MXP states and triggers
- Updated CHANGELOG and README for v2.5.0